### PR TITLE
Adds multi start spath and spath state caching

### DIFF
--- a/Detour/Include/DetourNavMeshQuery.h
+++ b/Detour/Include/DetourNavMeshQuery.h
@@ -194,6 +194,25 @@ public:
 					  const dtQueryFilter* filter,
 					  dtPolyRef* path, int* pathCount, const int maxPath) const;
 
+	/// Finds a path from the start polygon to the closest (by geodesic distance) to any of the goals.
+	/// Only traverse bidirectional edges.  Therefore it is not gaurenteed to find the shortest path 
+	/// or closest goal in meshes with directed offmesh connections.
+	///  @param[in] 	numGoals    The number of goals
+	///  @param[in]		startRef	The refrence id of the start polygon.
+	///  @param[in]		endRefs		List of the reference ids of the end polygons. [id * @p numGoals]
+	///  @param[in]		startPos	A position within the start polygon. [(x, y, z)]
+	///  @param[in]		endPoses	List of end positions within position within the end polygons. [(x, y, z) * @p numGoals]
+	///  @param[in]		filter		The polygon filter to apply to the query.
+	///  @param[out]	path		An ordered list of polygon references representing the path. (Start to end.) 
+	///  							[(polyRef) * @p pathCount]
+	///  @param[out]	pathCount	The number of polygons returned in the @p path array.
+	///  @param[in]		maxPath		The maximum number of polygons the @p path array can hold. [Limit: >= 1]
+	///  @param[out] 	foundGoalIdx Index into the list of goals specifying which goal was found. [opt]
+	dtStatus findBidirPathToAny(const int numGoals, dtPolyRef startRef, const dtPolyRef* endRefs,
+					  const float* startPos, const float* endPoses,
+					  const dtQueryFilter* filter,
+					  dtPolyRef* path, int* pathCount, const int maxPath, int* foundGoalIdx) const;
+
 	/// Finds the straight path from the start to the end position within the polygon corridor.
 	///  @param[in]		startPos			Path start position. [(x, y, z)]
 	///  @param[in]		endPos				Path end position. [(x, y, z)]
@@ -540,7 +559,14 @@ private:
 						   int* straightPathCount, const int maxStraightPath, const int options) const;
 
 	// Gets the path leading to the specified end node.
-	dtStatus getPathToNode(struct dtNode* endNode, dtPolyRef* path, int* pathCount, int maxPath) const;
+	dtStatus getPathToNode(struct dtNode* endNode, dtPolyRef* path, int* pathCount, int maxPath, int* startIdx) const;
+
+	// Internal implementation of multi-start A*
+	dtStatus findPathFromAny(const int numStars, const dtPolyRef* startRefs, dtPolyRef endRef,
+					  const float* startPoses, const float* endPos,
+					  const dtQueryFilter* filter,
+					  dtPolyRef* path, int* pathCount, const int maxPath,
+					  const bool reversedSearch, int* startIdx) const;
 	
 	const dtNavMesh* m_nav;				///< Pointer to navmesh data.
 


### PR DESCRIPTION
# Summary

Adds the ability to cache a the open/closed sets from a call to `findPath`.  This is useful as you can then very quickly get to path to a new goal from the same starting location.

Also changes to core search algorithm to support multiple starting locations.  Multiple start searching has little extra code complexity and no extra asymptotic complexity.  Multiple start also allows multiple goal as you can simple search from goals to start and then reverse the path.

# Changes

## Caching support changes

Adds a `dtQueryPathState` struct which contains its own version of the openList and nodePool and the list of starting points used for the last search.  `findPath` now takes an optional pointer to a `dtQueryPathState`.  If given a valid pointer, it will use the openList and nodePool in the `dtQueryPathState` and will reuse any partial state if possible.  Otherwise, it will use the openList and nodePool provided by `dtNavMeshQuery` and function as it does currently.

Adds `dtAllocQueryPathState` and `dtFreeQueryPathState` to support the allocation and deletion of the search states.

## Multi-start support changes

Adds a new method to `dtNavMeshQuery` called `findMultiStartPath`.  Note that `findPath` is simple implemented by calling `findMultiStartPath`.

`findMultiStartPath` takes the number of starting locations as its first argument, and then all arguments relating to the start locations (poly refs and (x, y, z) locations) are now lists.  The returned path will start at the *closet* (minimal cost/geodesic distance) starting location to the goal.

# Testing

These changes are backwards compatible with all existing tests and code.

To test caching

```c++
dtQueryPathState* state = dtAllocQueryPathState();
state->init(maxNodes);

// Runs in normal time
query->findPath(...., state);
// Returns almost instantly, and with the same path as above
query->findPath(...., state);

dtFreeQueryPathState(state);
```

To test multi start
```c++
query->findMultiStartPath(numStartingLocations, startPolyRefs,
        endPolyRef, startPoses, endPos, ....);
```



P.S. Sorry for the large diffs, I left my whitespace trimmer on and didn't notice until I had made too many changes to turn it off :(
This is a much simpler PR than the number of changes would indicate.